### PR TITLE
Handle missing auction_end_time column in database

### DIFF
--- a/database_manager.py
+++ b/database_manager.py
@@ -107,6 +107,17 @@ class DatabaseManager:
                 reminder_5m_sent BOOLEAN DEFAULT FALSE
             )
         ''')
+
+        # Ensure new columns exist for legacy installations
+        extra_columns = [
+            ("auction_end_time", "TIMESTAMP"),
+            ("reminder_1h_sent", "BOOLEAN DEFAULT FALSE"),
+            ("reminder_5m_sent", "BOOLEAN DEFAULT FALSE"),
+        ]
+        for col_name, col_def in extra_columns:
+            cursor.execute(
+                f"ALTER TABLE listings ADD COLUMN IF NOT EXISTS {col_name} {col_def}"
+            )
         
         cursor.execute('''
             CREATE TABLE IF NOT EXISTS reactions (
@@ -218,6 +229,21 @@ class DatabaseManager:
                 reminder_5m_sent BOOLEAN DEFAULT FALSE
             )
         ''')
+
+        # Ensure new columns exist for legacy installations
+        extra_columns = [
+            ("auction_end_time", "TIMESTAMP"),
+            ("reminder_1h_sent", "BOOLEAN DEFAULT FALSE"),
+            ("reminder_5m_sent", "BOOLEAN DEFAULT FALSE"),
+        ]
+        for col_name, col_def in extra_columns:
+            try:
+                cursor.execute(
+                    f"ALTER TABLE listings ADD COLUMN {col_name} {col_def}"
+                )
+            except Exception as e:
+                if "duplicate column name" not in str(e).lower():
+                    print(f"Column addition warning: {e}")
         
         cursor.execute('''
             CREATE TABLE IF NOT EXISTS reactions (


### PR DESCRIPTION
## Summary
- ensure listings table has auction_end_time and reminder flags even on legacy databases

## Testing
- `python -m py_compile database_manager.py`
- `python - <<'PY'
from database_manager import DatabaseManager
db = DatabaseManager()
db.init_database()
print('done')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68999761a70c8326886cd33194e9176e